### PR TITLE
Remove string prefix check

### DIFF
--- a/RSSParser/RSSParser.m
+++ b/RSSParser/RSSParser.m
@@ -233,10 +233,8 @@
                                          options:0
                                            range:NSMakeRange(0, string.length)];
     if (match) {
-        NSRange matchRange = match.range;   // entire captured tect
         NSRange captureRange = [match rangeAtIndex:1];
         NSString *urlString = [string substringWithRange:captureRange];
-        NSLog(@"URL Match: %@", urlString);
         return [self getNSURLFromString:urlString];
     }
     return nil;

--- a/RSSParser/RSSParser.m
+++ b/RSSParser/RSSParser.m
@@ -111,12 +111,10 @@
             [self.currentParsedItem setContent:self.currentParsedText];
 
             NSString *string = self.currentParsedText;
-            if ([string hasPrefix:@"<p><!--"] || [string hasPrefix:@"<!--"]) {
-                NSURL *url = [self parseVideoMediaURLfrom:string];
-                if (url) {
-                    [self.currentParsedItem setMediaURL:url];
-                    [self.currentParsedItem setMediaType:Video];
-                }
+            NSURL *url = [self parseVideoMediaURLfrom:string];
+            if (url) {
+                [self.currentParsedItem setMediaURL:url];
+                [self.currentParsedItem setMediaType:Video];
             }
         } else if ([elementName isEqualToString:@"link"]) {
             if (![self.currentParsedItem link] || ![[[self.currentParsedItem link] absoluteString] length]) {


### PR DESCRIPTION
Eliminates the String prefix check for `<p>` tag.

Simply scan the entire `content` and `content:encoded` tags for the special `videourl:=` HTML comment
